### PR TITLE
Fix upper-case letter

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -120,7 +120,7 @@
   "reactor",
   "stimpack",
   "combat shield",
-  "concussive Shells",
+  "concussive shells",
   "kd8 charge",
   "combat drugs",
   "jet pack",


### PR DESCRIPTION
`concussive shells`の`shells`だけ予想外に`Shells`と大文字になっていたので小文字にしました。
意図した大文字だったらスルーしてください！